### PR TITLE
Changes for Epoch Manager and Lock-Free Queue

### DIFF
--- a/src/EpochManager.chpl
+++ b/src/EpochManager.chpl
@@ -153,6 +153,10 @@ module EpochManager {
     proc try_reclaim() {
       manager.try_reclaim();
     }
+
+    proc unregister() {
+      manager.unregister(this:unmanaged);
+    }
   }
 
   class C {


### PR DESCRIPTION
@dgarvit 

I have a PR here that has changes for the repository. Currently there are a few issues that I have addressed...

1) You have two modules, example/LockFreeQueue.chpl and src/LockFreeQueue.chpl that create a conflict; I renamed the one in example/ directory to `ReclaimedLockFreeQueue`.
2) You had an incorrect benchmark for splitting enqueues and dequeues. Original code is seen here...

https://github.com/dgarvit/epoch-based-manager/blob/cf0641b71694e338de06d34536264e280a6c44fe/example/LockFreeQueue.chpl#L90-L121

The above creates one task per index, and is likely why you chose a small set of indices to test over. In my changes, just make even and odd tasks perform enqueue and dequeue respectively.

3) I added a `TokenWrapper` so that the user can retrieve an `owned` token, which is necessary when you want to use task-private variables. This is necessary for usage in a `forall`.
4) I add the manager to the data structure like I had originally intended. The manager is also made `owned` since it gets cleaned up once the data structure gets cleaned up.